### PR TITLE
Use File.join vs URI.join

### DIFF
--- a/lib/sendyr/client.rb
+++ b/lib/sendyr/client.rb
@@ -1,5 +1,3 @@
-require 'uri'
-
 module Sendyr
 	class Client
 		attr_reader :last_result, :api_key, :base_uri, :list_id

--- a/lib/sendyr/client.rb
+++ b/lib/sendyr/client.rb
@@ -120,7 +120,7 @@ module Sendyr
 		end
 
 		def url_for(path)
-			return @base_uri + path
+			return File.join(@base_uri, path)
 		end
 
 		def clean_body(result)

--- a/lib/sendyr/client.rb
+++ b/lib/sendyr/client.rb
@@ -120,7 +120,7 @@ module Sendyr
 		end
 
 		def url_for(path)
-			URI.join(@base_uri, path).to_s
+			return @base_uri + path
 		end
 
 		def clean_body(result)


### PR DESCRIPTION
This lets users where Sendy is installed outside of the root url use this gem. URI.join will just use the root url.
